### PR TITLE
Fix: ignore orphans warning when running API and UI

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -37,3 +37,6 @@ SERVER_IP=
 DOCKER_REGISTRY_NAME=
 KAMAL_REGISTRY_PASSWORD=
 SSH_USER=
+
+##################### docker env ############################
+COMPOSE_IGNORE_ORPHANS=true

--- a/bin/run_api.sh
+++ b/bin/run_api.sh
@@ -86,7 +86,7 @@ run() {
   fi
 
   bash_cmd="rm -fr tmp/pids/unicorn.pid && (bundle check || bundle install) && bundle exec unicorn -c config/unicorn.rb -E production -l 9393"
-  docker_run_cmd="docker compose -f docker-compose_api.yml -p ontoportal_docker run --remove-orphans --name api-service --rm -d  --service-ports api bash -c \"$bash_cmd\""
+  docker_run_cmd="docker compose -f docker-compose_api.yml -p ontoportal_docker run --name api-service --rm -d  --service-ports api bash -c \"$bash_cmd\""
   echo "[+] Starting the API"
   eval "$docker_run_cmd"
 

--- a/bin/run_cron.sh
+++ b/bin/run_cron.sh
@@ -13,7 +13,7 @@ start() {
 
 	source "$env_path"
 
-	docker_run_cmd="docker compose -f docker-compose_api.yml -p ontoportal_docker run  --remove-orphans --rm --name cron-service  --service-ports ncbo_cron bash -c \"$bash_cmd\""
+	docker_run_cmd="docker compose -f docker-compose_api.yml -p ontoportal_docker run --rm --name cron-service  --service-ports ncbo_cron bash -c \"$bash_cmd\""
 
 	echo "[+] Starting the CRON"
 	eval "$docker_run_cmd"

--- a/bin/run_ui.sh
+++ b/bin/run_ui.sh
@@ -77,7 +77,7 @@ run() {
 
   bash_cmd="(bundle check || bundle install) && $create_secrets_cmd && $create_credentials_cmd  && $create_db_cmd && $run_server_cmd"
 
-  docker_run_cmd="docker compose -f docker-compose_ui.yml -p ontoportal_docker run  --remove-orphans  --rm  --name ui-service --service-ports -d production bash -c \"$bash_cmd\""
+  docker_run_cmd="docker compose -f docker-compose_ui.yml -p ontoportal_docker run --rm  --name ui-service --service-ports -d production bash -c \"$bash_cmd\""
 
   eval "$docker_run_cmd"
 


### PR DESCRIPTION
### Context

- Issue: https://github.com/ontoportal-lirmm/ontoportal_docker/issues/5

### Solution

When docker compose is detecting orphans when running api and ui, this will not affect anything, the services still work correctly. So as suggested in the docker documentation [here](https://docs.docker.com/compose/how-tos/environment-variables/envvars/#compose_ignore_orphans) we can ignore the warning by adding COMPOSE_IGNORE_ORPHANS variable in the .env file